### PR TITLE
Scale ECS example down due to file storage

### DIFF
--- a/deploy/terraform_ecs/vars.tf
+++ b/deploy/terraform_ecs/vars.tf
@@ -7,7 +7,7 @@ locals {
 variable "app_count" {
   description = "How many instances to run"
   type        = number
-  default     = 2
+  default     = 1
 }
 
 variable "rcc_version" {


### PR DESCRIPTION
Due to #18 we can't actually properly use a scaled version... and even the 1 instance will eventually be wrong when it restarts for any reason.  Still, for now, at least it's a little easier to play with ephemerally.